### PR TITLE
add install entrypoint for registering codec

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -41,7 +41,6 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 target-version = "py310"
 fix = false
 # Group violations by containing file.
-format = "github"
 ignore-init-module-imports = true
 
 [mccabe]

--- a/ocf_blosc2/ocf_blosc2.py
+++ b/ocf_blosc2/ocf_blosc2.py
@@ -1,7 +1,6 @@
 import blosc2
 from numcodecs.abc import Codec
 from numcodecs.compat import ensure_contiguous_ndarray
-from numcodecs.registry import register_codec
 
 
 class Blosc2(Codec):
@@ -46,6 +45,3 @@ class Blosc2(Codec):
             self.clevel,
         )
         return r
-
-
-register_codec(Blosc2)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-""" 
+"""
 For more detailed information, please check the accompanying README.md.
 """
+
 from pathlib import Path
 
 from setuptools import find_packages, setup
@@ -20,4 +21,9 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),
+    entry_points={
+        "numcodecs.codecs": [
+            "blosc2 = ocf_blosc2:Blosc2",
+        ],
+    },
 )


### PR DESCRIPTION
Install now automatically registers codec — no need to import the module. As we discussed on Wednesday @peterdudfield.

Also, this repo could use a spring clean (no clear instructions for tests that have undefined vars, broken/deprecated linting config amongst other things). I tested it with opening the EUMETSAT xarrays without an import.
