### PR TITLE
Set max_buffer_size to blosc2.MAX_BUFFERSIZE

### DIFF
--- a/ocf_blosc2/ocf_blosc2.py
+++ b/ocf_blosc2/ocf_blosc2.py
@@ -22,7 +22,7 @@ class Blosc2(Codec):
     """
 
     codec_id = "blosc2"
-    max_buffer_size = 2**31 - 1
+    max_buffer_size = blosc2.MAX_BUFFERSIZE
 
     def __init__(self, cname="blosc2", clevel=5):  # noqa
         self.cname = cname


### PR DESCRIPTION
# Pull Request

## Description

The max_buffer_size was set to a value that is slightly higher than blosc2.MAX_BUFFERSIZE.

Fixes #

## How Has This Been Tested?

I checked that the proposed value works.

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
